### PR TITLE
make Julia 0.5 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.4
+Compat 0.9.5
 HttpCommon 0.2.4

--- a/src/HPack.jl
+++ b/src/HPack.jl
@@ -1,5 +1,7 @@
 module HPack
 
+using Compat
+
 import HttpCommon: Headers
 
 type DecodeError <: Exception

--- a/src/decode.jl
+++ b/src/decode.jl
@@ -31,7 +31,7 @@ end
 function decode_string(buf::IOBuffer)
     huffman = buf.data[buf.ptr] & 128 == 128
     len = decode_integer(buf, 7)
-    str = readbytes(buf, len)
+    str = read(buf, len)
     if huffman
         str = huffman_decode_bytes(str)
     end
@@ -75,10 +75,10 @@ function decode(table::DynamicTable, buf::IOBuffer)
 
         if initial_octet & 128 == 128 # Indexed
             header = decode_indexed(table, buf)
-            headers[ascii(header[1])] = ascii(header[2])
+            headers[ascii(Compat.String(header[1]))] = ascii(Compat.String(header[2]))
         elseif initial_octet & 64 == 64 # Literal with incremental indexing
             header = decode_literal(table, buf, true)
-            headers[ascii(header[1])] = ascii(header[2])
+            headers[ascii(Compat.String(header[1]))] = ascii(Compat.String(header[2]))
         elseif initial_octet & 32 == 32 # Size update
             new_size = decode_integer(buf, 5)
             set_max_table_size!(table, new_size)
@@ -87,7 +87,7 @@ function decode(table::DynamicTable, buf::IOBuffer)
             headers[ascii(header[1])] = ascii(header[2])
         else # Literal without indexing
             header = decode_literal(table, buf, false)
-            headers[ascii(header[1])] = ascii(header[2])
+            headers[ascii(Compat.String(header[1]))] = ascii(Compat.String(header[2]))
         end
     end
 

--- a/src/encode.jl
+++ b/src/encode.jl
@@ -52,5 +52,5 @@ function encode(table::DynamicTable, headers::Headers; options...)
         end
     end
 
-    return takebuf_array(buf)
+    return take!(buf)
 end

--- a/src/huffman.jl
+++ b/src/huffman.jl
@@ -27,7 +27,7 @@ function huffman_encode_bytes(data::Array{UInt8}, offset::Int=0, length::Int=len
         write(out, UInt8(current))
     end
 
-    return takebuf_array(out)
+    return take!(out)
 end
 
 
@@ -63,5 +63,5 @@ function huffman_decode_bytes(buf::Array{UInt8}, length::Int=length(buf))
         return Nullable{Array{UInt8}} # Decoder ended prematurely
     end
 
-    return takebuf_array(out)
+    return take!(out)
 end

--- a/src/huffmandata.jl
+++ b/src/huffmandata.jl
@@ -1,4 +1,4 @@
-HUFFMAN_SYMBOL_TABLE =
+const HUFFMAN_SYMBOL_TABLE =
     [
      [13 0x1ff8]
      [23 0x7fffd8]
@@ -259,7 +259,7 @@ HUFFMAN_SYMBOL_TABLE =
      [30 0x3fffffff]
      ]
 
-HUFFMAN_DECODE_TABLE =
+const HUFFMAN_DECODE_TABLE =
     [
      [
       [4 0x00 0]

--- a/src/table.jl
+++ b/src/table.jl
@@ -101,7 +101,7 @@ STATIC_TABLE =
      (b"www-authenticate", b"")
      ]
 
-function get_header(table::DynamicTable, index::Int)
+function get_header(table::DynamicTable, index)
     # IETF's table indexing is 1-based.
     if index <= length(STATIC_TABLE)
         return STATIC_TABLE[index]


### PR DESCRIPTION
- uses Compat.jl to make this Julia 0.5 compatible
- update travis test matrix
- change `get_header` to take `UInt` also as type for `index`